### PR TITLE
Update mint install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,16 +46,10 @@ Project Linter to lint & autocorrect your non-code best practices.
 
 ### Using [Mint](https://github.com/yonaskolb/Mint):
 
-To **install** ProjLint simply run this command:
+To **install** the latest version of ProjLint simply run this command:
 
 ```shell
 $ mint install JamitLabs/ProjLint
-```
-
-To **update** to the newest version of TranslationManager when you have an old version already installed run:
-
-```shell
-$ mint update JamitLabs/ProjLint
 ```
 
 ## Usage


### PR DESCRIPTION
This removes the reference to `mint update`, as `install` will also install the latest version, without re-installing it. `update` was actually removed in the newest versions of mint.

This also removes a reference to TranslationManager